### PR TITLE
use Scala 3.3.2

### DIFF
--- a/project.scala
+++ b/project.scala
@@ -1,5 +1,5 @@
 // Main
-//> using scala "3.4.0-RC3"
+//> using scala "3.3.2"
 //> using options -source:future -Yexplicit-nulls
 //> using options -project enhanced-string-interpolator -siteroot ${.}
 

--- a/src/main/test/example/RegexSuite.scala
+++ b/src/main/test/example/RegexSuite.scala
@@ -28,7 +28,7 @@ class RegexSuite extends munit.FunSuite:
     """)
     val queryMsg =
       """unbalanced parentheses when parsing regex from format string: "...(((O|X))""""
-    assert(errors.exists(_.message.contains(queryMsg)))
+    assertEquals(true, clue(errors).exists(_.message.contains(queryMsg)))
 
   test("regex newline"):
     val in = """foo


### PR DESCRIPTION
3.3.2 release seems to fix the crash that occurred in 3.3.1 (and is also fixed in 3.4.0)